### PR TITLE
Push nightly, git-sha, branch, and pr docker tags

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,10 +15,46 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKERHUB_USERNAME: felipecrs
+      IMAGE_NAME: devcontainer
     steps:
       - uses: actions/checkout@v4
-      - name: Setup QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Docker meta (base)
+        id: docker-meta-base
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+          tags: |
+            type=schedule,pattern=nightly
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,enable=${{ github.event_name == 'push' }}
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || github.event_name == 'schedule' }}
+            type=raw,value=base,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) || github.event_name == 'schedule' }}
+          bake-target: base
+      - name: Docker meta (github)
+        id: docker-meta-github
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}
+            ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
+            prefix=github-
+          tags: |
+            type=schedule,pattern=nightly
+            type=schedule,pattern={{date 'YYYYMMDD'}}
+            type=ref,event=branch
+            # Prefix needs to be repeated for these, refs:
+            # https://github.com/docker/metadata-action/issues/270
+            type=ref,event=pr,prefix=github-pr-
+            type=sha,prefix=github-sha-,enable=${{ github.event_name == 'push' }}
+          bake-target: github
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
@@ -37,7 +73,11 @@ jobs:
         with:
           pull: true
           no-cache: true
-          push: ${{ ! startsWith(github.ref, 'refs/pull/') }}
+          push: ${{ github.event_name != 'pull_request' }}
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.docker-meta-base.outputs.bake-file }}
+            ${{ steps.docker-meta-github.outputs.bake-file }}
       - name: Update Docker Hub description
         uses: peter-evans/dockerhub-description@v3
         with:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,31 +1,14 @@
-function "create_tags" {
-	params = [image_name]
-    variadic_params = tags
-
-    result = concat(
-        [for t in tags : "${image_name}:${t}"], 
-        [for t in tags : "ghcr.io/${image_name}:${t}"]
-    )
-}
-
-variable "IMAGE_NAME" {
-	default = "felipecrs/devcontainer"
-}
-
 group "default" {
 	targets = ["base", "github"]
 }
 
 target "base" {
     context = "."
-	dockerfile = "Dockerfile"
     target = "base"
-	tags = create_tags("${IMAGE_NAME}", "latest", "base")
     cache-to = ["type=inline"]
 }
 
 target "github" {
     inherits = ["base"]
     target = "github"
-    tags = create_tags("${IMAGE_NAME}", "github")
 }


### PR DESCRIPTION
This should allow people to easily pin the version of the devcontainer image.